### PR TITLE
AC-8877: terraform/stack setup fails with broken pip dependency

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -47,8 +47,3 @@ execute "install-pip" do
   command 'sudo curl -s -N https://bootstrap.pypa.io/ez_setup.py -o - | sudo python3.6 && sudo python3.6 -m easy_install pip'
   not_if { ::File.exists?(pip_binary) }
 end
-
-execute 'setuptools' do
-  command 'pip3 install setuptools==41.0.1 | python3'
-  retries 2
-end

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -49,5 +49,6 @@ execute "install-pip" do
 end
 
 execute 'setuptools' do
-  command 'pip3 install setuptools==41.0.1'
+  command 'pip3 install setuptools==41.0.1 | python3'
+  retries 2
 end


### PR DESCRIPTION
This fixes an issue preventing the 'setup' command to fail from opsworks.

to test - 

- we have a few broken stacks in opsworks (indicated by the red for example test-30). choose one and run 'setup'. 
- note that running setup fails.
- go to stack settings and change the branch to 'test-buildout-fix'. this is a branch in the opsworks-web-deploy repo that is preconfigured to point to this branch for the python cookbooks.
<img width="656" alt="Screen Shot 2021-05-28 at 11 06 19" src="https://user-images.githubusercontent.com/196425/120004579-f3c13780-bfa4-11eb-8d41-35b3e8ce81fb.png">
- run the 'update custom cookbooks' command on the stack
- once that completes re-run setup
- note that it succeeds